### PR TITLE
Delete guzzlehttp/guzzle, aura/sql

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,7 @@
     "require": {
         "php": "^7.3 || ^8.0",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "^7.3",
-        "symfony/process": "^5.2.7",
-        "aura/sql": "^3.0"
+        "symfony/process": "^5.2.7"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.4",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": "^7.3 || ^8.0",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "^6.5.5",
+        "guzzlehttp/guzzle": "^7.3",
         "symfony/process": "^5.2.7",
         "aura/sql": "^3.0"
     },

--- a/src/QueryMerger.php
+++ b/src/QueryMerger.php
@@ -18,7 +18,7 @@ final class QueryMerger
     public function __invoke(string $uri, array $query): Uri
     {
         $path = (string) parse_url($uri, PHP_URL_PATH);
-        $uriQueryString = (string) parse_url((string) $uri, PHP_URL_QUERY);
+        $uriQueryString = (string) parse_url($uri, PHP_URL_QUERY);
         parse_str($uriQueryString, $uriQuery);
         $mergedQuery = $uriQuery + $query;
 


### PR DESCRIPTION
## guzzle ver.7
~~^6.5.5 -> ^7.3~~
-> delete from composer.json

## aura/sql
delete from composer.json

## fix psalm error
```
ERROR: RedundantCast - src/QueryMerger.php:21:46 - Redundant cast to string (see https://psalm.dev/262)
        $uriQueryString = (string) parse_url((string) $uri, PHP_URL_QUERY);
