### PR TITLE
Curl only request

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,14 @@
         "aura/sql": "^3 || ^4 || ^5",
         "bear/resource": "^1.17",
         "psr/log": "^1 || ^2 || ^3",
-        "ray/aura-sql-module": "^1.10",
         "ray/di": "^2.14",
         "symfony/process": "^5.2.7"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.4",
         "bear/package": "^1.10",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.5",
+        "ray/aura-sql-module": "^1.10"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,16 +1,2 @@
 parameters:
 	ignoreErrors:
-		-
-			message: "#^Parameter \\#2 \\$query of method BEAR\\\\Dev\\\\Http\\\\HttpResource\\:\\:safeLog\\(\\) expects array\\<string\\>, array\\<string, mixed\\> given\\.$#"
-			count: 1
-			path: src/Http/HttpResource.php
-
-		-
-			message: "#^Parameter \\#3 \\$query of method BEAR\\\\Dev\\\\Http\\\\HttpResource\\:\\:unsafeLog\\(\\) expects array\\<string\\>, array\\<string, mixed\\> given\\.$#"
-			count: 4
-			path: src/Http/HttpResource.php
-
-		-
-			message: "#^Property BEAR\\\\Dev\\\\Http\\\\HttpResource\\:\\:\\$resource \\(BEAR\\\\Resource\\\\ResourceInterface\\) does not accept mixed\\.$#"
-			count: 1
-			path: src/Http/HttpResource.php

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0"?>
 <psalm
     errorLevel="3"
-    resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
-    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor-bin/tools/vendor/vimeo/psalm/config.xsd"
 >
     <projectFiles>
         <directory name="src" />
         <ignoreFiles>
             <directory name="vendor" />
+            <directory name="src-deprecated" />
         </ignoreFiles>
     </projectFiles>
 </psalm>

--- a/src/Http/CreateResponse.php
+++ b/src/Http/CreateResponse.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Dev\Http;
+
+use BEAR\Resource\NullResourceObject;
+use BEAR\Resource\ResourceObject;
+
+use function array_key_exists;
+use function array_pop;
+use function array_shift;
+use function assert;
+use function implode;
+use function json_decode;
+use function preg_match;
+
+use const PHP_EOL;
+
+final class CreateResponse
+{
+    public function __invoke(string $pathQuery, array $output): ResourceObject
+    {
+        $headers = $body = [];
+        $status = array_shift($output);
+        do {
+            $line = array_shift($output);
+            $headers[] = $line;
+        } while ($line !== '');
+
+        do {
+            $line = array_shift($output);
+            $body[] = $line;
+        } while ($line !== null);
+
+        array_pop($headers);
+        array_pop($body);
+        preg_match('/\d{3}/', $status, $match);
+        assert(array_key_exists(0, $match));
+        $jsonBody = implode(PHP_EOL, $body);
+        $code = $match[0];
+        $ro = new NullResourceObject();
+        $ro->uri = $pathQuery;
+        $ro->code = (int) $code;
+        $ro->headers = $headers;
+        $ro->body = (array) json_decode($jsonBody);
+        $ro->view = $jsonBody;
+
+        return $ro;
+    }
+}

--- a/src/Http/CreateResponse.php
+++ b/src/Http/CreateResponse.php
@@ -13,13 +13,14 @@ use function array_pop;
 use function array_shift;
 use function assert;
 use function implode;
+use function is_string;
 use function json_decode;
 use function preg_match;
 
 use const PHP_EOL;
 
 /**
- * Create ResouceObject from curl output
+ * Create ResourceObject from curl output
  */
 final class CreateResponse
 {
@@ -29,15 +30,16 @@ final class CreateResponse
     public function __invoke(Uri $uri, array $output): ResourceObject
     {
         $headers = $body = [];
-        $status = array_shift($output);
+        $status = (string) array_shift($output);
         do {
             $line = array_shift($output);
+            assert(is_string($line));
             $headers[] = $line;
         } while ($line !== '');
 
         do {
             $line = array_shift($output);
-            $body[] = $line;
+            $body[] = (string) $line;
         } while ($line !== null);
 
         $ro = new NullResourceObject();
@@ -75,11 +77,11 @@ final class CreateResponse
             $keyedHeader[$matched[1]] = $matched[2];
         }
 
-        return $keyedHeader;
+        return $keyedHeader; // @phpstan-ignore-line
     }
 
     /**
-     * @param array<string, string> $body
+     * @param array<string> $body
      */
     private function getJsonView(array $body): string
     {

--- a/src/Http/HttpResource.php
+++ b/src/Http/HttpResource.php
@@ -21,12 +21,13 @@ use function json_encode;
 use function sprintf;
 
 use const FILE_APPEND;
+use const JSON_THROW_ON_ERROR;
 use const PHP_EOL;
 
 final class HttpResource implements ResourceInterface
 {
     /** @var string */
-    private $logFile = '';
+    private $logFile;
 
     /** @var string */
     private $baseUri;
@@ -180,7 +181,7 @@ final class HttpResource implements ResourceInterface
     }
 
     /**
-     * @param array<string> $query
+     * @param array<mixed> $query
      */
     private function safeRequest(string $path, array $query): ResourceObject
     {
@@ -193,12 +194,12 @@ final class HttpResource implements ResourceInterface
     }
 
     /**
-     * @param array<string> $query
+     * @param array<mixed> $query
      */
     private function unsafeRequest(string $method, string $path, array $query): ResourceObject
     {
         $uri = ($this->queryMerger)($path, $query);
-        $json = json_encode($uri->query);
+        $json = json_encode($uri->query, JSON_THROW_ON_ERROR);
         $url = sprintf('%s%s', $this->baseUri, $uri->path);
 
         $curl = sprintf("curl -s -i -H 'Content-Type:application/json' -X %s -d '%s' %s", $method, $json, $url);

--- a/src/Http/HttpResource.php
+++ b/src/Http/HttpResource.php
@@ -5,24 +5,19 @@ declare(strict_types=1);
 namespace BEAR\Dev\Http;
 
 use BEAR\Dev\QueryMerger;
-use BEAR\Resource\Module\ResourceModule;
+use BEAR\Dev\Uri;
 use BEAR\Resource\RequestInterface;
 use BEAR\Resource\ResourceInterface;
 use BEAR\Resource\ResourceObject;
 use LogicException;
-use Ray\Di\Injector;
 
-use function array_key_exists;
-use function assert;
 use function exec;
 use function file_exists;
 use function file_put_contents;
 use function http_build_query;
 use function implode;
 use function in_array;
-use function is_array;
 use function json_encode;
-use function parse_url;
 use function sprintf;
 
 use const FILE_APPEND;
@@ -30,9 +25,6 @@ use const PHP_EOL;
 
 final class HttpResource implements ResourceInterface
 {
-    /** @var ResourceInterface */
-    private $resource;
-
     /** @var string */
     private $logFile = '';
 
@@ -45,6 +37,9 @@ final class HttpResource implements ResourceInterface
     /** @var QueryMerger */
     private $queryMerger;
 
+    /** @var CreateResponse */
+    private $createResponse;
+
     public function __construct(string $host, string $index, string $logFile = 'php://stderr')
     {
         $this->baseUri = sprintf('http://%s', $host);
@@ -52,9 +47,8 @@ final class HttpResource implements ResourceInterface
         $this->resetLog($logFile);
 
         $this->startServer($host, $index);
-        $module = new ResourceModule('BEAR/Sunday');
-        $this->resource = (new Injector($module))->getInstance(ResourceInterface::class);
         $this->queryMerger = new QueryMerger();
+        $this->createResponse = new CreateResponse();
     }
 
     private function startServer(string $host, string $index): void
@@ -130,11 +124,7 @@ final class HttpResource implements ResourceInterface
      */
     public function get(string $uri, array $query = []): ResourceObject
     {
-        $httpUri = $this->getHttpUrl($uri);
-        $response = $this->resource->{__FUNCTION__}($httpUri, $query);
-        $this->safeLog($uri, $query);
-
-        return $response;
+        return $this->safeRequest($uri, $query);
     }
 
     /**
@@ -142,11 +132,7 @@ final class HttpResource implements ResourceInterface
      */
     public function post(string $uri, array $query = []): ResourceObject
     {
-        $httpUri = $this->getHttpUrl($uri);
-        $response = $this->resource->{__FUNCTION__}($httpUri, $query);
-        $this->unsafeLog('POST', $uri, $query);
-
-        return $response;
+        return $this->unsafeRequest('POST', $uri, $query);
     }
 
     /**
@@ -154,11 +140,7 @@ final class HttpResource implements ResourceInterface
      */
     public function put(string $uri, array $query = []): ResourceObject
     {
-        $httpUri = $this->getHttpUrl($uri);
-        $response = $this->resource->{__FUNCTION__}($httpUri, $query);
-        $this->unsafeLog('PUT', $uri, $query);
-
-        return $response;
+        return $this->unsafeRequest('PUT', $uri, $query);
     }
 
     /**
@@ -166,11 +148,7 @@ final class HttpResource implements ResourceInterface
      */
     public function patch(string $uri, array $query = []): ResourceObject
     {
-        $httpUri = $this->getHttpUrl($uri);
-        $response = $this->resource->{__FUNCTION__}($httpUri, $query);
-        $this->unsafeLog('PATCH', $uri, $query);
-
-        return $response;
+        return $this->unsafeRequest('PATCH', $uri, $query);
     }
 
     /**
@@ -178,11 +156,7 @@ final class HttpResource implements ResourceInterface
      */
     public function delete(string $uri, array $query = []): ResourceObject
     {
-        $httpUri = $this->getHttpUrl($uri);
-        $response = $this->resource->{__FUNCTION__}($httpUri, $query);
-        $this->unsafeLog('DELETE', $uri, $query);
-
-        return $response;
+        return $this->unsafeRequest('DELETE', $uri, $query);
     }
 
     /**
@@ -208,42 +182,44 @@ final class HttpResource implements ResourceInterface
     /**
      * @param array<string> $query
      */
-    private function safeLog(string $uri, array $query): void
+    private function safeRequest(string $path, array $query): ResourceObject
     {
-        $uri = ($this->queryMerger)($uri, $query);
+        $uri = ($this->queryMerger)($path, $query);
         $queryParameter = $uri->query ? '?' . http_build_query($uri->query) : '';
-        $curl = sprintf("curl -s -i '%s%s%s'", $this->baseUri, $uri->path, $queryParameter);
-        exec($curl, $output);
-        $responseLog = implode(PHP_EOL, $output);
-        $log = sprintf("%s\n\n%s", $curl, $responseLog) . PHP_EOL . PHP_EOL;
-        file_put_contents($this->logFile, $log, FILE_APPEND);
+        $pathQuery = sprintf('%s%s', $uri->path, $queryParameter);
+        $curl = sprintf("curl -s -i '%s%s'", $this->baseUri, $pathQuery);
+
+        return $this->request($curl, $uri);
     }
 
     /**
      * @param array<string> $query
      */
-    private function unsafeLog(string $method, string $uri, array $query): void
+    private function unsafeRequest(string $method, string $path, array $query): ResourceObject
     {
-        $uri = ($this->queryMerger)($uri, $query);
+        $uri = ($this->queryMerger)($path, $query);
         $json = json_encode($uri->query);
         $curl = sprintf("curl -s -i -H 'Content-Type:application/json' -X %s -d '%s' %s%s", $method, $json, $this->baseUri, $uri->path);
-        exec($curl, $output);
+
+        return $this->request($curl, $uri);
+    }
+
+    /**
+     * @param array<string> $output
+     */
+    public function log(array $output, string $curl): void
+    {
         $responseLog = implode(PHP_EOL, $output);
         $log = sprintf("%s\n\n%s", $curl, $responseLog) . PHP_EOL . PHP_EOL;
         file_put_contents($this->logFile, $log, FILE_APPEND);
     }
 
-    public function getHttpUrl(string $uri): string
+    public function request(string $curl, Uri $uri): ResourceObject
     {
-        $pUri = parse_url($uri);
-        assert(is_array($pUri));
-        assert(array_key_exists('path', $pUri));
-        if (array_key_exists('scheme', $pUri) && ($pUri['scheme'] === 'http' || $pUri['scheme'] === 'https')) {
-            return $uri;
-        }
+        exec($curl, $output);
+        $ro = ($this->createResponse)($uri->path, $output);
+        $this->log($output, $curl);
 
-        $query = isset($pUri['query']) ? sprintf('?%s', $pUri['query']) : '';
-
-        return sprintf('%s%s%s', $this->baseUri, $pUri['path'], $query);
+        return $ro;
     }
 }

--- a/src/QueryMerger.php
+++ b/src/QueryMerger.php
@@ -13,7 +13,7 @@ use const PHP_URL_QUERY;
 final class QueryMerger
 {
     /**
-     * @param array<string, string> $query
+     * @param array<mixed> $query
      */
     public function __invoke(string $uri, array $query): Uri
     {

--- a/tests/Http/index.php
+++ b/tests/Http/index.php
@@ -6,4 +6,4 @@ use MyVendor\MyProject\Bootstrap;
 
 require dirname(__DIR__) . '/Fake/app/vendor/autoload.php';
 
-exit((new Bootstrap())('hal-app', $GLOBALS, $_SERVER));
+exit((new Bootstrap())('prod-hal-app', $GLOBALS, $_SERVER));


### PR DESCRIPTION
Remove PHP resource request in HTTP hypermedia test.

This avoids problems when the same request cannot be made twice at the same time, such as inserting the same ID into a DB, and speeds up the process.