### PR TITLE
Support HAL link follow in HttpResource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,8 @@
 /.phpcs-cache
 /.php_cs.cache
 /vendor-bin/tools/vendor/
-tests/Http/log/HttpResourceClientTest.log
+tests/Http/log/*.log
 coverage.xml
-tests/Http/log/app.log
 .idea
 !.idea/
 .idea/*

--- a/src/Http/AbstractWorkflowTest.php
+++ b/src/Http/AbstractWorkflowTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Dev\Http;
+
+use BEAR\Resource\Code;
+use BEAR\Resource\ResourceInterface;
+use BEAR\Resource\ResourceObject;
+use PHPUnit\Framework\TestCase;
+
+use function is_string;
+use function str_starts_with;
+use function strtolower;
+
+abstract class AbstractWorkflowTest extends TestCase
+{
+    /** @var array<class-string, ResourceInterface> */
+    private static array $resources = [];
+    protected ResourceInterface $resource;
+
+    protected function setUp(): void
+    {
+        $this->resource = self::$resources[static::class] ??= $this->newResource();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        unset(self::$resources[static::class]);
+    }
+
+    abstract protected function newResource(): ResourceInterface;
+
+    /**
+     * Follows a safe HAL/Resource link with GET.
+     *
+     * Unsafe `do*` transitions call post/put/delete directly in the workflow
+     * step because HAL links do not carry an HTTP method.
+     *
+     * @param array<string, mixed> $query
+     */
+    protected function follow(ResourceObject $response, string $rel, array $query = []): ResourceObject
+    {
+        $next = $this->resource->href($rel, $query, $response);
+        $this->assertSame(Code::OK, $next->code);
+
+        return $next;
+    }
+
+    protected function followLocation(ResourceObject $response, string|null $expectedLocation = null): ResourceObject
+    {
+        $location = $this->header($response, 'Location');
+        $this->assertIsString($location);
+        if ($expectedLocation !== null) {
+            $this->assertSame($expectedLocation, $location);
+        }
+
+        $next = $this->resource->get($this->resourceUriForLocation($location));
+        $this->assertSame(Code::OK, $next->code);
+
+        return $next;
+    }
+
+    protected function bodyValue(ResourceObject $response, string $key): mixed
+    {
+        $body = $response->body;
+        $this->assertIsArray($body);
+        $this->assertArrayHasKey($key, $body);
+
+        return $body[$key];
+    }
+
+    protected function header(ResourceObject $response, string $name): string|null
+    {
+        foreach ($response->headers as $header => $value) {
+            if (! is_string($header) || ! is_string($value)) {
+                continue;
+            }
+
+            if (strtolower($header) !== strtolower($name)) {
+                continue;
+            }
+
+            return $value;
+        }
+
+        return null;
+    }
+
+    private function resourceUriForLocation(string $location): string
+    {
+        if (str_starts_with($location, '/')) {
+            return 'page://self' . $location;
+        }
+
+        return $location;
+    }
+}

--- a/src/Http/CreateResponse.php
+++ b/src/Http/CreateResponse.php
@@ -12,6 +12,7 @@ use function array_key_exists;
 use function array_pop;
 use function array_shift;
 use function count;
+use function end;
 use function implode;
 use function json_decode;
 use function preg_match;
@@ -79,8 +80,7 @@ final class CreateResponse
         $keyedHeader = [];
         array_pop($headers);
         foreach ($headers as $header) {
-            preg_match('/(.+):\s(.+)/', $header, $matched);
-            if (! array_key_exists(1, $matched) || ! array_key_exists(2, $matched)) {
+            if (preg_match('/(.+):\s(.+)/', $header, $matched) !== 1) {
                 // Skip malformed headers
                 continue;
             }
@@ -94,7 +94,7 @@ final class CreateResponse
     /** @param array<string> $body */
     private function getJsonView(array $body): string
     {
-        if (count($body) > 0) {
+        if (count($body) > 0 && end($body) === '') {
             array_pop($body);
         }
 

--- a/src/Http/Exception/HalLinkNotFoundException.php
+++ b/src/Http/Exception/HalLinkNotFoundException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Dev\Http\Exception;
+
+use DomainException;
+
+final class HalLinkNotFoundException extends DomainException
+{
+}

--- a/src/Http/HttpResource.php
+++ b/src/Http/HttpResource.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BEAR\Dev\Http;
 
+use BEAR\Dev\Http\Exception\HalLinkNotFoundException;
 use BEAR\Dev\QueryMerger;
 use BEAR\Resource\Method;
 use BEAR\Resource\RequestInterface;
@@ -14,10 +15,11 @@ use Koriym\PhpServer\PhpServer;
 use LogicException;
 use Override;
 
-use function curl_close;
+use function array_key_exists;
 use function curl_exec;
 use function curl_init;
 use function curl_setopt;
+use function debug_backtrace;
 use function escapeshellarg;
 use function explode;
 use function file_exists;
@@ -25,9 +27,15 @@ use function file_put_contents;
 use function http_build_query;
 use function implode;
 use function in_array;
+use function is_array;
+use function is_object;
 use function is_string;
 use function json_encode;
+use function preg_replace;
 use function sprintf;
+use function str_ends_with;
+use function str_starts_with;
+use function strtolower;
 use function strtoupper;
 use function trim;
 
@@ -36,23 +44,24 @@ use const CURLOPT_HEADER;
 use const CURLOPT_HTTPHEADER;
 use const CURLOPT_POSTFIELDS;
 use const CURLOPT_RETURNTRANSFER;
+use const DEBUG_BACKTRACE_IGNORE_ARGS;
+use const DIRECTORY_SEPARATOR;
 use const FILE_APPEND;
 use const JSON_THROW_ON_ERROR;
 use const PHP_EOL;
 
 final class HttpResource implements ResourceInterface
 {
-    private string $logFile;
+    private string $logPath;
     private string $baseUri;
     private static PhpServer $server;
     private readonly QueryMerger $queryMerger;
     private readonly CreateResponse $createResponse;
 
-    public function __construct(string $host, string $index, string $logFile = 'php://stderr')
+    public function __construct(string $host, string $index, string $logPath = 'php://stderr')
     {
         $this->baseUri = sprintf('http://%s', $host);
-        $this->logFile = $logFile;
-        $this->resetLog($logFile);
+        $this->logPath = $logPath;
 
         $this->startServer($host, $index);
         $this->queryMerger = new QueryMerger();
@@ -72,19 +81,6 @@ final class HttpResource implements ResourceInterface
         self::$server = new PhpServer($host, $index);
         self::$server->start();
         $started[] = $id;
-    }
-
-    private function resetLog(string $logFile): void
-    {
-        /** @var array<string> $started */
-        static $started = [];
-
-        if (in_array($logFile, $started) || ! file_exists($logFile)) {
-            return;
-        }
-
-        file_put_contents($logFile, '');
-        $started[] = $logFile;
     }
 
     /**
@@ -126,10 +122,34 @@ final class HttpResource implements ResourceInterface
     #[Override]
     public function href(string $rel, array $query = [], ResourceObject|null $ro = null): ResourceObject
     {
-        throw new LogicException();
+        if ($ro === null || ! is_array($ro->body)) {
+            throw new HalLinkNotFoundException('A source ResourceObject with HAL links is required.');
+        }
+
+        $links = $ro->body['_links'] ?? null;
+        if (is_object($links)) {
+            $links = (array) $links;
+        }
+
+        if (! is_array($links) || ! array_key_exists($rel, $links)) {
+            throw new HalLinkNotFoundException(sprintf('HAL link rel `%s` is not available.', $rel));
+        }
+
+        $link = $links[$rel];
+        if (is_object($link)) {
+            $link = (array) $link;
+        }
+
+        $href = is_array($link) ? ($link['href'] ?? null) : null;
+        if (! is_string($href)) {
+            throw new HalLinkNotFoundException(sprintf('HAL link rel `%s` has no href.', $rel));
+        }
+
+        return $this->get($href, $query);
     }
 
     /** @param array<string, mixed> $query */
+    #[Override]
     public function newRequest(Method $method, string $uri, array $query = []): RequestInterface
     {
         unset($method, $uri, $query);
@@ -138,6 +158,7 @@ final class HttpResource implements ResourceInterface
     }
 
     /** @param array<string, mixed> $query */
+    #[Override]
     public function crawl(string $uri, string $linkKey, array $query = []): ResourceObject
     {
         unset($uri, $linkKey, $query);
@@ -244,9 +265,57 @@ final class HttpResource implements ResourceInterface
     /** @param array<string> $output */
     public function log(array $output, string $curlCommand): void
     {
+        $logFile = $this->logFile();
+        $this->resetLog($logFile);
         $responseLog = implode(PHP_EOL, $output);
         $log = sprintf("%s\n\n%s", $curlCommand, $responseLog) . PHP_EOL . PHP_EOL;
-        file_put_contents($this->logFile, $log, FILE_APPEND);
+        file_put_contents($logFile, $log, FILE_APPEND);
+    }
+
+    private function logFile(): string
+    {
+        if ($this->logPath === 'php://stderr' || str_ends_with($this->logPath, '.log')) {
+            return $this->logPath;
+        }
+
+        return $this->logPath . DIRECTORY_SEPARATOR . $this->currentTestLogName();
+    }
+
+    private function currentTestLogName(): string
+    {
+        foreach (debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS) as $frame) {
+            $function = $frame['function'];
+            if (! str_starts_with($function, 'test')) {
+                continue;
+            }
+
+            return self::kebabCase($function) . '.log';
+        }
+
+        return 'http-resource.log';
+    }
+
+    private static function kebabCase(string $name): string
+    {
+        $kebab = preg_replace('/(?<!^)[A-Z]/', '-$0', $name) ?? $name;
+
+        return strtolower($kebab);
+    }
+
+    private function resetLog(string $logFile): void
+    {
+        /** @var array<string> $reset */
+        static $reset = [];
+
+        if ($logFile === 'php://stderr' || in_array($logFile, $reset, true)) {
+            return;
+        }
+
+        if (file_exists($logFile)) {
+            file_put_contents($logFile, '');
+        }
+
+        $reset[] = $logFile;
     }
 
     public function request(string $url, string $method, string $curlCommand, string|null $body = null): ResourceObject
@@ -286,7 +355,6 @@ final class HttpResource implements ResourceInterface
         }
 
         $response = curl_exec($ch);
-        curl_close($ch);
 
         if (! is_string($response)) {
             return [];

--- a/template/tests/Http/WorkflowTest.php
+++ b/template/tests/Http/WorkflowTest.php
@@ -4,26 +4,18 @@ declare(strict_types=1);
 
 namespace BEAR\Skeleton\Http;
 
-use BEAR\Dev\Http\BuiltinServerStartTrait;
-use BEAR\Resource\ResourceObject;
+use BEAR\Dev\Http\HttpResource;
+use BEAR\Resource\ResourceInterface;
 use BEAR\Skeleton\Hypermedia\WorkflowTest as Workflow;
-use BEAR\Skeleton\Injector;
 
 class WorkflowTest extends Workflow
 {
-    use BuiltinServerStartTrait;
-
-    protected function setUp(): void
+    protected function newResource(): ResourceInterface
     {
-        $_SERVER['Authorization'] = '_secret_token_';
-        $this->resource = $this->getHttpResourceClient(Injector::getInstance('app'), self::class);
-    }
-
-    public function testIndex(): ResourceObject
-    {
-        $index = $this->resource->get($this->httpHost . '/');
-        $this->assertSame(200, $index->code);
-
-        return $index;
+        return new HttpResource(
+            '127.0.0.1:8088',
+            __DIR__ . '/index.php',
+            __DIR__ . '/log',
+        );
     }
 }

--- a/template/tests/Hypermedia/WorkflowTest.php
+++ b/template/tests/Hypermedia/WorkflowTest.php
@@ -4,24 +4,21 @@ declare(strict_types=1);
 
 namespace BEAR\Skeleton\Hypermedia;
 
+use BEAR\Dev\Http\AbstractWorkflowTest;
 use BEAR\Resource\ResourceInterface;
 use BEAR\Resource\ResourceObject;
 use BEAR\Skeleton\Injector;
-use PHPUnit\Framework\TestCase;
-use Ray\Di\InjectorInterface;
 
-class WorkflowTest extends TestCase
+use function assert;
+
+class WorkflowTest extends AbstractWorkflowTest
 {
-    /** @var ResourceInterface */
-    protected $resource;
-
-    /** @var InjectorInterface */
-    protected $injector;
-
-    protected function setUp(): void
+    protected function newResource(): ResourceInterface
     {
-        $this->injector = Injector::getInstance('app');
-        $this->resource = $this->injector->getInstance(ResourceInterface::class);
+        $resource = Injector::getInstance('app')->getInstance(ResourceInterface::class);
+        assert($resource instanceof ResourceInterface);
+
+        return $resource;
     }
 
     public function testIndex(): ResourceObject
@@ -31,17 +28,4 @@ class WorkflowTest extends TestCase
 
         return $index;
     }
-
-//    /**
-//     * @depends testIndex
-//     */
-//    public function testRelx(ResourceObject $response) : ResourceObject
-//    {
-//        $json = (string) $response;
-//        $href = json_decode($json)->_links->{'name:rel'}->href;
-//        $ro = $this->resource->get($href);
-//        $this->assertSame(200, $ro->code);
-//
-//        return $ro;
-//    }
 }

--- a/tests/Fake/app/src/Resource/Page/Index.php
+++ b/tests/Fake/app/src/Resource/Page/Index.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace MyVendor\MyProject\Resource\Page;
 
+use BEAR\Resource\Annotation\Link;
 use BEAR\Resource\ResourceObject;
 
 class Index extends ResourceObject
 {
+    #[Link(rel: 'next', href: '/linked')]
     public function onGet()
     {
         $this->body = ['method' => __FUNCTION__];

--- a/tests/Fake/app/src/Resource/Page/Linked.php
+++ b/tests/Fake/app/src/Resource/Page/Linked.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyProject\Resource\Page;
+
+use BEAR\Resource\ResourceObject;
+
+class Linked extends ResourceObject
+{
+    public function onGet(): static
+    {
+        $this->body = ['method' => __FUNCTION__, 'page' => 'linked'];
+
+        return $this;
+    }
+}

--- a/tests/Fake/app/tests/Http/WorkflowTest.php
+++ b/tests/Fake/app/tests/Http/WorkflowTest.php
@@ -4,26 +4,18 @@ declare(strict_types=1);
 
 namespace MyVendor\MyProject\Http;
 
-use BEAR\Dev\Http\BuiltinServerStartTrait;
-use BEAR\Resource\ResourceObject;
+use BEAR\Dev\Http\HttpResource;
+use BEAR\Resource\ResourceInterface;
 use MyVendor\MyProject\Hypermedia\WorkflowTest as Workflow;
-use MyVendor\MyProject\Injector;
 
 class WorkflowTest extends Workflow
 {
-    use BuiltinServerStartTrait;
-
-    protected function setUp(): void
+    protected function newResource(): ResourceInterface
     {
-        $_SERVER['Authorization'] = '_secret_token_';
-        $this->resource = $this->getHttpResourceClient(Injector::getInstance('app'), self::class);
-    }
-
-    public function testIndex(): ResourceObject
-    {
-        $index = $this->resource->get($this->httpHost . '/');
-        $this->assertSame(200, $index->code);
-
-        return $index;
+        return new HttpResource(
+            '127.0.0.1:8088',
+            __DIR__ . '/index.php',
+            __DIR__ . '/log',
+        );
     }
 }

--- a/tests/Fake/app/tests/Hypermedia/WorkflowTest.php
+++ b/tests/Fake/app/tests/Hypermedia/WorkflowTest.php
@@ -4,24 +4,21 @@ declare(strict_types=1);
 
 namespace MyVendor\MyProject\Hypermedia;
 
+use BEAR\Dev\Http\AbstractWorkflowTest;
 use BEAR\Resource\ResourceInterface;
 use BEAR\Resource\ResourceObject;
 use MyVendor\MyProject\Injector;
-use PHPUnit\Framework\TestCase;
-use Ray\Di\InjectorInterface;
 
-class WorkflowTest extends TestCase
+use function assert;
+
+class WorkflowTest extends AbstractWorkflowTest
 {
-    /** @var ResourceInterface */
-    protected $resource;
-
-    /** @var InjectorInterface */
-    protected $injector;
-
-    protected function setUp(): void
+    protected function newResource(): ResourceInterface
     {
-        $this->injector = Injector::getInstance('app');
-        $this->resource = $this->injector->getInstance(ResourceInterface::class);
+        $resource = Injector::getInstance('app')->getInstance(ResourceInterface::class);
+        assert($resource instanceof ResourceInterface);
+
+        return $resource;
     }
 
     public function testIndex(): ResourceObject
@@ -32,16 +29,11 @@ class WorkflowTest extends TestCase
         return $index;
     }
 
-//    /**
-//     * @depends testIndex
-//     */
-//    public function testRelFoo(ResourceObject $response): ResourceObject
-//    {
-//        $json = (string) $response;
-//        $href = json_decode($json)->_links->{'name:foo'}->href;
-//        $ro = $this->resource->get($href);
-//        $this->assertSame(200, $ro->code);
-//
-//        return $ro;
-//    }
+    /**
+     * @depends testIndex
+     */
+    public function testNext(ResourceObject $response): ResourceObject
+    {
+        return $this->follow($response, 'next');
+    }
 }

--- a/tests/Http/HttpResourceTest.php
+++ b/tests/Http/HttpResourceTest.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace BEAR\Dev\Http;
 
 use BEAR\Dev\Http\Exception\HalLinkNotFoundException;
+use BEAR\Resource\ResourceInterface;
+use BEAR\Resource\ResourceObject;
 use BEAR\Resource\Uri;
+use LogicException;
 use PHPUnit\Framework\TestCase;
 
 use function assert;
@@ -85,6 +88,21 @@ class HttpResourceTest extends TestCase
         $this->assertFileExists(__DIR__ . '/log/test-href-follows-hal-link-with-get.log');
     }
 
+    public function testWorkflowFollowUsesHalHrefGet(): void
+    {
+        $index = __DIR__ . '/index.php';
+        assert(file_exists($index));
+        $resource = new HttpResource('127.0.0.1:8081', $index, __DIR__ . '/log');
+        $ro = $resource->get('/');
+
+        $workflow = new AbstractWorkflowTestHarness('runTest');
+        $workflow->setResource($resource);
+
+        $next = $workflow->followPublic($ro, 'next');
+        $this->assertSame(200, $next->code);
+        $this->assertStringContainsString('"page": "linked"', $next->view);
+    }
+
     public function testHrefThrowsHalLinkNotFoundExceptionForMissingHalLink(): void
     {
         $index = __DIR__ . '/index.php';
@@ -145,5 +163,23 @@ class HttpResourceTest extends TestCase
         ]);
         $this->assertSame(200, $ro->code);
         $this->assertStringContainsString('"method": "onPost"', $ro->view);
+    }
+}
+
+final class AbstractWorkflowTestHarness extends AbstractWorkflowTest
+{
+    public function setResource(ResourceInterface $resource): void
+    {
+        $this->resource = $resource;
+    }
+
+    public function followPublic(ResourceObject $response, string $rel): ResourceObject
+    {
+        return $this->follow($response, $rel);
+    }
+
+    protected function newResource(): ResourceInterface
+    {
+        throw new LogicException();
     }
 }

--- a/tests/Http/HttpResourceTest.php
+++ b/tests/Http/HttpResourceTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace BEAR\Dev\Http;
 
+use BEAR\Dev\Http\Exception\HalLinkNotFoundException;
+use BEAR\Resource\Uri;
 use PHPUnit\Framework\TestCase;
 
 use function assert;
@@ -19,7 +21,7 @@ class HttpResourceTest extends TestCase
     {
         $index = dirname(__DIR__) . '/Fake/app/public/index.php';
         assert(file_exists($index));
-        $this->resource = new HttpResource('127.0.0.1:8080', $index, __DIR__ . '/log/app.log');
+        $this->resource = new HttpResource('127.0.0.1:8080', $index, __DIR__ . '/log');
     }
 
     public function testOnGet(): void
@@ -65,6 +67,47 @@ class HttpResourceTest extends TestCase
         $ro = $resource->get('http://127.0.0.1:8080/');
         $this->assertSame(200, $ro->code);
         $this->assertStringContainsString('"method": "onGet"', $ro->view);
+    }
+
+    public function testHrefFollowsHalLinkWithGet(): void
+    {
+        $index = __DIR__ . '/index.php';
+        assert(file_exists($index));
+        $resource = new HttpResource('127.0.0.1:8081', $index, __DIR__ . '/log');
+
+        $ro = $resource->get('/');
+        $this->assertSame(200, $ro->code);
+        $this->assertStringContainsString('"_links"', $ro->view);
+
+        $next = $resource->href('next', [], $ro);
+        $this->assertSame(200, $next->code);
+        $this->assertStringContainsString('"page": "linked"', $next->view);
+        $this->assertFileExists(__DIR__ . '/log/test-href-follows-hal-link-with-get.log');
+    }
+
+    public function testHrefThrowsHalLinkNotFoundExceptionForMissingHalLink(): void
+    {
+        $index = __DIR__ . '/index.php';
+        assert(file_exists($index));
+        $resource = new HttpResource('127.0.0.1:8081', $index, __DIR__ . '/log');
+        $ro = $resource->get('/');
+
+        $this->expectException(HalLinkNotFoundException::class);
+        $resource->href('missing', [], $ro);
+    }
+
+    public function testCreateResponseKeepsSingleLineJsonBody(): void
+    {
+        $uri = new Uri('http://127.0.0.1:8080/');
+        $ro = (new CreateResponse())($uri, [
+            'HTTP/1.1 200 OK',
+            'Content-Type: application/json',
+            '',
+            '{"method":"onGet"}',
+        ]);
+
+        $this->assertSame('{"method":"onGet"}', $ro->view);
+        $this->assertSame('onGet', $ro->body['method']);
     }
 
     public function testPostWithSpecialCharactersSingleQuote(): void


### PR DESCRIPTION
## Summary
- add HAL `_links.<rel>.href` GET follow support to `HttpResource::href()`
- add `HalLinkNotFoundException` under `src/Http/Exception` for missing HAL rel/href cases
- derive HTTP log file names from PHPUnit test method names in kebab-case

## Tests
- `vendor/bin/phpunit --no-coverage tests/Http/HttpResourceTest.php`
- `composer test`
- `composer cs`
- `php -d memory_limit=512M ./vendor/bin/phpstan analyse -c phpstan.neon --no-progress`
- `vendor/bin/psalm --show-info=true`
- `./vendor/bin/phpmd src text ./phpmd.xml`