### PR TITLE
Fix master analysis-and-cs: remove unnecessary Psalm InvalidAttribute suppression

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -16,14 +16,5 @@
         <UnusedClass errorLevel="suppress" />
         <PossiblyUnusedMethod errorLevel="suppress" />
         <MissingOverrideAttribute errorLevel="suppress" />
-        <!-- Psalm 6.15 false-positive: #[Override] on methods is reported as "cannot be used on a function" -->
-        <InvalidAttribute>
-            <errorLevel type="suppress">
-                <file name="src/DevInvoker.php" />
-                <file name="src/Halo/HaloModule.php" />
-                <file name="src/Halo/HaloRenderer.php" />
-                <file name="src/Http/HttpResource.php" />
-            </errorLevel>
-        </InvalidAttribute>
     </issueHandlers>
 </psalm>


### PR DESCRIPTION
## Summary

Follow-up to #27. After #27 was merged, `master` fails the `analysis-and-cs` job.

`psalm.xml` (merged via #27) suppresses `InvalidAttribute` for the four files using `#[Override]`. That report was a **Psalm 6.15 false-positive that is already fixed in Psalm 6.16**, which CI resolves. Under 6.16 the suppression matches nothing, so Psalm raises `UnusedIssueHandlerSuppression` (psalm.dev/326) and the job fails:

```
psalm.xml:0:0: UnusedIssueHandlerSuppression: Suppressed issue type "InvalidAttribute" for
/src/DevInvoker.php, /src/Halo/HaloModule.php, /src/Halo/HaloRenderer.php, /src/Http/HttpResource.php
was not thrown.
```

This PR removes that suppression, restoring `psalm.xml` to the pre-#27 baseline (a single 9-line deletion). `#[Override]` is no longer flagged by the Psalm version CI uses, so no suppression is needed.

## Verification (with Psalm 6.16.1, the version CI resolves)

- `composer sa` (phpstan + psalm) ✅ **No errors** (no `UnusedIssueHandlerSuppression`)
- `composer cs` (phpcs) ✅
- `phpmd src text ./phpmd.xml` ✅
- `composer-require-checker check ./composer.json` ✅
- `phpunit` ✅ (23 tests, 48 assertions)

https://claude.ai/code/session_01GiaFcnDuqWEkt8XM7CPwur

---
_Generated by [Claude Code](https://claude.ai/code/session_01GiaFcnDuqWEkt8XM7CPwur)_