### PR TITLE
Convert AbstractWorkflowTest to WorkflowTestTrait; refresh README and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `HttpResource::href()` follows a HAL `_links` relation with a `GET` request, throwing `HalLinkNotFoundException` when the relation or its `href` is missing
+- `WorkflowTestTrait` for hypermedia workflow tests (`follow()`, `followLocation()`, `bodyValue()`, `header()`); the same scenario can run in-process or over HTTP by overriding `newResource()`
+- Per-test HTTP access logs: pass a log directory to `HttpResource` to write one `<test-name>.log` per test method
+- PHP 8.5 support
+
+### Changed
+- Raised the minimum PHP version to 8.2
+- Bumped the `bear/resource` requirement to `^1.31`
+- Moved `phpunit/phpunit` to `require`, since the package ships `WorkflowTestTrait` for use in consumer test suites
+- Modernized the codebase for PHP 8.2+ (constructor property promotion, readonly properties)
+- Moved `src-deprecated/` from autoload to autoload-dev
+
+### Removed
+- Unused dependencies: `ext-filter`, `psr/log`, `symfony/process`
+
+## [1.2.2] - 2025-12-30
+
+### Changed
+- `HttpResource` now uses the native cURL extension instead of shell `exec()`, fixing payloads that contain shell metacharacters
+
+### Added
+- `ext-curl` requirement
+
 ## [1.2.1] - 2025-08-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.3.0] - 2026-06-06
 
 ### Added
 - `HttpResource::href()` follows a HAL `_links` relation with a `GET` request, throwing `HalLinkNotFoundException` when the relation or its `href` is missing

--- a/README.md
+++ b/README.md
@@ -46,15 +46,21 @@ class DevModule extends AbstractModule
 
 **Features:**
 - Automatic local server startup
-- HTTP request logging to file
-- Full HTTP method support (GET, POST, PUT, DELETE, etc.)
+- HTTP request logging (to STDERR, a single file, or per-test files)
+- Full HTTP method support (GET, POST, PUT, PATCH, DELETE)
+- HAL link following with `href()`
 - Request/response capture for testing workflows
 
 ```php
 use BEAR\Dev\Http\HttpResource;
 
-// Start server and create HTTP client
-$resource = new HttpResource('127.0.0.1:8099', '/path/to/index.php', '/path/to/curl.log');
+// Start the built-in server and create an HTTP client.
+// The third argument is the log destination and is optional
+// (defaults to 'php://stderr'):
+//   - 'php://stderr'       : write logs to STDERR (default)
+//   - '/path/to/file.log'  : write every request to a single file
+//   - '/path/to/log'       : a directory; one '<test-name>.log' per test method
+$resource = new HttpResource('127.0.0.1:8080', '/path/to/public/index.php', __DIR__ . '/log');
 
 // Make HTTP requests
 $ro = $resource->get('/users');
@@ -64,21 +70,64 @@ $ro = $resource->post('/users', ['name' => 'John', 'email' => 'john@example.com'
 assert($ro->code === 201);
 ```
 
+#### Following HAL links
+
+`href()` follows a HAL `_links` relation from a response with a `GET` request:
+
+```php
+$index = $resource->get('/');
+// {"_links": {"next": {"href": "/users"}}}
+
+$users = $resource->href('next', [], $index);
+assert($users->code === 200);
+```
+
+A `HalLinkNotFoundException` is thrown when the relation or its `href` is missing.
+
 #### HTTP Access Log
 
-All HTTP requests made through `HttpResource` are automatically logged with full curl command equivalents:
+Each request is logged with its equivalent `curl` command followed by the raw response:
 
 ```bash
-curl -s -i 'http://127.0.0.1:8099/users'
+curl -s -i 'http://127.0.0.1:8080/users'
 
 HTTP/1.1 200 OK
 Content-Type: application/hal+json
 ...
 ```
 
+### Workflow Testing
+
+`WorkflowTestTrait` helps drive hypermedia workflow tests. Implement `newResource()`, then navigate with `follow()` (a safe `GET` via a HAL `_links` relation) and `followLocation()` (a `GET` of the `Location` header returned by an unsafe transition). The same test body can run in-process or over HTTP by changing what `newResource()` returns.
+
+```php
+use BEAR\Dev\Http\HttpResource;
+use BEAR\Dev\Http\WorkflowTestTrait;
+use BEAR\Resource\ResourceInterface;
+use PHPUnit\Framework\TestCase;
+
+final class WorkflowTest extends TestCase
+{
+    use WorkflowTestTrait;
+
+    protected function newResource(): ResourceInterface
+    {
+        return new HttpResource('127.0.0.1:8080', __DIR__ . '/public/index.php', __DIR__ . '/log');
+    }
+
+    public function testWorkflow(): void
+    {
+        $index = $this->resource->get('/');
+        $next = $this->follow($index, 'next');
+        $this->assertSame(200, $next->code);
+    }
+}
+```
+
 ## Requirements
 
-- PHP 8.0 or higher
+- PHP 8.2 or higher
+- ext-curl
 - BEAR.Sunday framework
 
 ## Development

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,3 +4,8 @@ parameters:
   level: max
   paths:
     - src
+  ignoreErrors:
+    # Shipped test-helper trait; only used from test suites, not from src.
+    -
+      identifier: trait.unused
+      path: src/Http/WorkflowTestTrait.php

--- a/src/Http/WorkflowTestTrait.php
+++ b/src/Http/WorkflowTestTrait.php
@@ -12,21 +12,32 @@ use PHPUnit\Framework\TestCase;
 use function str_starts_with;
 use function strtolower;
 
-abstract class AbstractWorkflowTest extends TestCase
+/**
+ * Hypermedia workflow testing helpers.
+ *
+ * Use this trait in a PHPUnit test that drives a BEAR.Sunday resource client,
+ * implement {@see newResource()}, then navigate with {@see follow()} (safe HAL
+ * link GET) and {@see followLocation()} (GET the `Location` after an unsafe
+ * transition). The same test body can run against both an in-process resource
+ * and {@see HttpResource} by overriding `newResource()`.
+ *
+ * @psalm-require-extends TestCase
+ */
+trait WorkflowTestTrait
 {
     /** @var array<class-string, ResourceInterface> */
-    private static array $resources = [];
+    private static array $workflowResources = [];
     protected ResourceInterface $resource;
 
     protected function setUp(): void
     {
         $class = static::class;
-        $this->resource = self::$resources[$class] ??= $this->newResource();
+        $this->resource = self::$workflowResources[$class] ??= $this->newResource();
     }
 
     public static function tearDownAfterClass(): void
     {
-        unset(self::$resources[static::class]);
+        unset(self::$workflowResources[static::class]);
     }
 
     abstract protected function newResource(): ResourceInterface;

--- a/template/tests/Hypermedia/WorkflowTest.php
+++ b/template/tests/Hypermedia/WorkflowTest.php
@@ -4,15 +4,18 @@ declare(strict_types=1);
 
 namespace BEAR\Skeleton\Hypermedia;
 
-use BEAR\Dev\Http\AbstractWorkflowTest;
+use BEAR\Dev\Http\WorkflowTestTrait;
 use BEAR\Resource\ResourceInterface;
 use BEAR\Resource\ResourceObject;
 use BEAR\Skeleton\Injector;
+use PHPUnit\Framework\TestCase;
 
 use function assert;
 
-class WorkflowTest extends AbstractWorkflowTest
+class WorkflowTest extends TestCase
 {
+    use WorkflowTestTrait;
+
     protected function newResource(): ResourceInterface
     {
         $resource = Injector::getInstance('app')->getInstance(ResourceInterface::class);

--- a/tests/Fake/app/tests/Hypermedia/WorkflowTest.php
+++ b/tests/Fake/app/tests/Hypermedia/WorkflowTest.php
@@ -4,15 +4,18 @@ declare(strict_types=1);
 
 namespace MyVendor\MyProject\Hypermedia;
 
-use BEAR\Dev\Http\AbstractWorkflowTest;
+use BEAR\Dev\Http\WorkflowTestTrait;
 use BEAR\Resource\ResourceInterface;
 use BEAR\Resource\ResourceObject;
 use MyVendor\MyProject\Injector;
+use PHPUnit\Framework\TestCase;
 
 use function assert;
 
-class WorkflowTest extends AbstractWorkflowTest
+class WorkflowTest extends TestCase
 {
+    use WorkflowTestTrait;
+
     protected function newResource(): ResourceInterface
     {
         $resource = Injector::getInstance('app')->getInstance(ResourceInterface::class);

--- a/tests/Http/WorkflowFollowTest.php
+++ b/tests/Http/WorkflowFollowTest.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace BEAR\Dev\Http;
 
 use BEAR\Resource\ResourceInterface;
+use PHPUnit\Framework\TestCase;
 
 use function assert;
 use function file_exists;
 
-class WorkflowFollowTest extends AbstractWorkflowTest
+class WorkflowFollowTest extends TestCase
 {
+    use WorkflowTestTrait;
+
     protected function newResource(): ResourceInterface
     {
         $index = __DIR__ . '/index.php';


### PR DESCRIPTION
## Summary

Converts the workflow test helper from an **abstract base class** (`AbstractWorkflowTest extends TestCase`) into a **trait** (`WorkflowTestTrait`), and brings the docs up to date.

**Why the trait:** the base class only needed to extend `TestCase` because its helpers call `$this->assertSame()` etc. That forced consumers to spend PHP's single inheritance slot on it. A trait keeps the same ergonomics (`$this->follow(...)`, `$this->followLocation(...)`) while letting a project keep its own base `TestCase`.

## Changes

### Refactor
- `src/Http/AbstractWorkflowTest.php` → `src/Http/WorkflowTestTrait.php` (trait). Same helpers: `follow()` (safe HAL `_links` GET via `ResourceInterface::href()`), `followLocation()` (GET the `Location` header after an unsafe transition), `bodyValue()`, `header()`, plus the per-class resource cache and `newResource()`.
- `@psalm-require-extends TestCase` so Psalm resolves the inherited assertion methods inside the trait.
- Workflow tests now `extends TestCase` + `use WorkflowTestTrait`. **Cross-transport reuse is preserved**: the Http workflow test still extends the Hypermedia one and inherits the trait through it, so the same scenario runs in-process and over HTTP by overriding `newResource()`.
- `phpstan.neon`: ignore `trait.unused` for the shipped trait (used only from test suites).

### Docs
- **README**: require PHP 8.2+ / ext-curl; document the optional `HttpResource` log argument (`php://stderr` default, single file, or per-test directory); document HAL link following via `href()` / `HalLinkNotFoundException`; add a Workflow Testing section using `WorkflowTestTrait`.
- **CHANGELOG**: add an `[Unreleased]` section covering the unreleased work (HAL link follow, `WorkflowTestTrait`, PHP 8.5, min PHP 8.2, `bear/resource ^1.31`, `phpunit` → `require`, dependency cleanup) and backfill the missing `[1.2.2]` entry.

## Verification (Psalm 6.16.1 / PHPStan 2.1.38, matching CI)

- `composer cs` ✅
- `phpstan analyse` ✅ (No errors)
- `psalm` ✅ (No errors)
- `phpmd` ✅
- `composer-require-checker` ✅
- `phpunit` ✅ (23 tests, 48 assertions)

https://claude.ai/code/session_01GiaFcnDuqWEkt8XM7CPwur