### PR TITLE
Add HTML link header renderer

### DIFF
--- a/src/DevInvoker.php
+++ b/src/DevInvoker.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace BEAR\Dev;
 
+use BackedEnum;
 use BEAR\Resource\AbstractRequest;
 use BEAR\Resource\InvokerInterface;
-use BEAR\Resource\Method;
 use BEAR\Resource\ResourceObject;
 use Override;
 use Ray\Aop\WeavedInterface;
@@ -19,6 +19,7 @@ use function extension_loaded;
 use function is_array;
 use function is_int;
 use function is_object;
+use function is_scalar;
 use function is_string;
 use function json_encode;
 use function memory_get_usage;
@@ -57,12 +58,26 @@ final class DevInvoker implements InvokerInterface
     {
         $resource = $this->getRo($request);
 
-        if ($request->method === Method::OPTIONS || $request->method === Method::HEAD) {
+        $method = $this->methodValue($request->method);
+        if ($method === 'options' || $method === 'head') {
             // OPTIONS and HEAD requests are not processed by DevInvoker
             return $this->invoker->invoke($request); // @codeCoverageIgnore
         }
 
         return $this->devInvoke($resource, $request);
+    }
+
+    private function methodValue(mixed $method): string
+    {
+        if ($method instanceof BackedEnum) {
+            return (string) $method->value;
+        }
+
+        if (is_scalar($method)) {
+            return (string) $method;
+        }
+
+        return '';
     }
 
     private function devInvoke(ResourceObject $resource, AbstractRequest $request): ResourceObject

--- a/src/Html/ErrorLogHtmlLinkAuditLogger.php
+++ b/src/Html/ErrorLogHtmlLinkAuditLogger.php
@@ -7,7 +7,11 @@ namespace BEAR\Dev\Html;
 use Override;
 
 use function error_log;
+use function is_string;
+use function preg_replace;
 use function sprintf;
+use function strlen;
+use function substr;
 
 final class ErrorLogHtmlLinkAuditLogger implements HtmlLinkAuditLoggerInterface
 {
@@ -16,10 +20,20 @@ final class ErrorLogHtmlLinkAuditLogger implements HtmlLinkAuditLoggerInterface
     {
         error_log(sprintf(
             '[BEAR.Dev.HtmlLinkAudit] warning rel=%s method=%s href=%s reason=%s',
-            $link->rel,
-            $link->method,
-            $link->href,
-            $reason,
+            $this->sanitize($link->rel),
+            $this->sanitize($link->method),
+            $this->sanitize($link->href),
+            $this->sanitize($reason),
         ));
+    }
+
+    private function sanitize(string $value): string
+    {
+        $sanitized = preg_replace('/[\x00-\x1F\x7F]/', '', $value);
+        if (! is_string($sanitized)) {
+            return '';
+        }
+
+        return strlen($sanitized) > 512 ? substr($sanitized, 0, 512) . '...' : $sanitized;
     }
 }

--- a/src/Html/ErrorLogHtmlLinkAuditLogger.php
+++ b/src/Html/ErrorLogHtmlLinkAuditLogger.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Dev\Html;
+
+use Override;
+
+use function error_log;
+use function sprintf;
+
+final class ErrorLogHtmlLinkAuditLogger implements HtmlLinkAuditLoggerInterface
+{
+    #[Override]
+    public function warning(LinkHeader $link, string $reason): void
+    {
+        error_log(sprintf(
+            '[BEAR.Dev.HtmlLinkAudit] warning rel=%s method=%s href=%s reason=%s',
+            $link->rel,
+            $link->method,
+            $link->href,
+            $reason,
+        ));
+    }
+}

--- a/src/Html/HtmlAffordance.php
+++ b/src/Html/HtmlAffordance.php
@@ -26,7 +26,12 @@ final readonly class HtmlAffordance
 
     private function containsToken(string $value, string $token): bool
     {
-        $tokens = preg_split('/\s+/', trim($value));
+        $value = trim($value);
+        if ($value === '' || $token === '') {
+            return false;
+        }
+
+        $tokens = preg_split('/\s+/', $value);
         if (! is_array($tokens)) {
             return false;
         }

--- a/src/Html/HtmlAffordance.php
+++ b/src/Html/HtmlAffordance.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Dev\Html;
+
+use function in_array;
+use function is_array;
+use function preg_split;
+use function trim;
+
+final readonly class HtmlAffordance
+{
+    public function __construct(
+        public string $href,
+        public string $method,
+        public string $rel = '',
+        public string $class = '',
+    ) {
+    }
+
+    public function hasToken(string $token): bool
+    {
+        return $this->containsToken($this->rel, $token) || $this->containsToken($this->class, $token);
+    }
+
+    private function containsToken(string $value, string $token): bool
+    {
+        $tokens = preg_split('/\s+/', trim($value));
+        if (! is_array($tokens)) {
+            return false;
+        }
+
+        return in_array($token, $tokens, true);
+    }
+}

--- a/src/Html/HtmlLinkAuditLoggerInterface.php
+++ b/src/Html/HtmlLinkAuditLoggerInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Dev\Html;
+
+interface HtmlLinkAuditLoggerInterface
+{
+    public function warning(LinkHeader $link, string $reason): void;
+}

--- a/src/Html/HtmlLinkAuditor.php
+++ b/src/Html/HtmlLinkAuditor.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Dev\Html;
+
+use function html_entity_decode;
+use function is_string;
+use function preg_match;
+use function preg_match_all;
+use function strtolower;
+
+use const ENT_HTML5;
+use const ENT_QUOTES;
+use const PREG_SET_ORDER;
+
+final readonly class HtmlLinkAuditor
+{
+    public function __construct(
+        private HtmlLinkAuditLoggerInterface $logger,
+    ) {
+    }
+
+    /** @param list<LinkHeader> $links */
+    public function audit(array $links, string|null $html): void
+    {
+        if (! is_string($html) || $html === '') {
+            foreach ($links as $link) {
+                $this->logger->warning($link, 'html-missing');
+            }
+
+            return;
+        }
+
+        $affordances = $this->affordances($html);
+        foreach ($links as $link) {
+            $this->auditLink($link, $affordances);
+        }
+    }
+
+    /** @param list<HtmlAffordance> $affordances */
+    private function auditLink(LinkHeader $link, array $affordances): void
+    {
+        $targetMatches = [];
+        foreach ($affordances as $affordance) {
+            if ($affordance->href !== $link->href) {
+                continue;
+            }
+
+            $targetMatches[] = $affordance;
+        }
+
+        if ($targetMatches === []) {
+            $this->logger->warning($link, 'target-missing');
+
+            return;
+        }
+
+        $methodMatches = [];
+        $method = strtolower($link->method);
+        foreach ($targetMatches as $affordance) {
+            if ($affordance->method !== $method) {
+                continue;
+            }
+
+            $methodMatches[] = $affordance;
+        }
+
+        if ($methodMatches === []) {
+            $this->logger->warning($link, 'method-mismatch');
+
+            return;
+        }
+
+        foreach ($methodMatches as $affordance) {
+            if ($affordance->hasToken($link->rel)) {
+                return;
+            }
+        }
+
+        $this->logger->warning($link, 'semantic-token-missing');
+    }
+
+    /** @return list<HtmlAffordance> */
+    private function affordances(string $html): array
+    {
+        $affordances = [];
+        if (preg_match_all('/<(a|area|link|form)\b(?P<attrs>[^>]*)>/i', $html, $matches, PREG_SET_ORDER) !== 1) {
+            return $affordances;
+        }
+
+        foreach ($matches as $match) {
+            $tag = strtolower($match[1]);
+            $attrs = $match['attrs'];
+
+            $href = $tag === 'form' ? $this->attribute($attrs, 'action') : $this->attribute($attrs, 'href');
+            if ($href === null || $href === '') {
+                continue;
+            }
+
+            $method = $tag === 'form' ? strtolower($this->attribute($attrs, 'method') ?? 'get') : 'get';
+            $affordances[] = new HtmlAffordance(
+                $href,
+                $method,
+                $this->attribute($attrs, 'rel') ?? '',
+                $this->attribute($attrs, 'class') ?? '',
+            );
+        }
+
+        return $affordances;
+    }
+
+    private function attribute(string $attrs, string $name): string|null
+    {
+        if (preg_match('/\b' . $name . '\s*=\s*(?:"([^"]*)"|\'([^\']*)\'|([^\s>]+))/i', $attrs, $match) !== 1) {
+            return null;
+        }
+
+        $value = $match[1] ?? $match[2] ?? $match[3] ?? '';
+
+        return html_entity_decode($value, ENT_QUOTES | ENT_HTML5);
+    }
+}

--- a/src/Html/LinkHeader.php
+++ b/src/Html/LinkHeader.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Dev\Html;
+
+use function addcslashes;
+use function strtolower;
+
+final readonly class LinkHeader
+{
+    public function __construct(
+        public string $rel,
+        public string $href,
+        public string $method = 'get',
+        public string $title = '',
+    ) {
+    }
+
+    public function headerValue(): string
+    {
+        $header = '<' . $this->href . '>; rel="' . $this->quote($this->rel) . '"';
+        $method = strtolower($this->method);
+        if ($method !== '') {
+            $header .= '; method="' . $this->quote($method) . '"';
+        }
+
+        if ($this->title !== '') {
+            $header .= '; title="' . $this->quote($this->title) . '"';
+        }
+
+        return $header;
+    }
+
+    private function quote(string $value): string
+    {
+        return addcslashes($value, '\"');
+    }
+}

--- a/src/Html/LinkHeaderModule.php
+++ b/src/Html/LinkHeaderModule.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Dev\Html;
+
+use BEAR\Resource\RenderInterface;
+use Override;
+use Ray\Di\AbstractModule;
+use Ray\Di\Scope;
+
+final class LinkHeaderModule extends AbstractModule
+{
+    public function __construct(AbstractModule $module)
+    {
+        parent::__construct($module);
+    }
+
+    #[Override]
+    protected function configure(): void
+    {
+        $this->rename(RenderInterface::class, 'html');
+        $this->bind(RenderInterface::class)->to(LinkHeaderRenderer::class)->in(Scope::SINGLETON);
+        $this->bind(HtmlLinkAuditor::class);
+        $this->bind(HtmlLinkAuditLoggerInterface::class)->to(ErrorLogHtmlLinkAuditLogger::class);
+    }
+}

--- a/src/Html/LinkHeaderRenderer.php
+++ b/src/Html/LinkHeaderRenderer.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Dev\Html;
+
+use BEAR\Resource\Annotation\Link;
+use BEAR\Resource\RenderInterface;
+use BEAR\Resource\ResourceObject;
+use BEAR\Resource\ReverseLinkerInterface;
+use Override;
+use Ray\Aop\ReflectionMethod;
+use Ray\Di\Di\Named;
+
+use function implode;
+use function is_array;
+use function is_string;
+use function method_exists;
+use function str_starts_with;
+use function strlen;
+use function substr;
+use function ucfirst;
+use function uri_template;
+
+final class LinkHeaderRenderer implements RenderInterface
+{
+    private const HEADER = 'Link';
+    private const PAGE_URI_PREFIX = 'page://self';
+
+    public function __construct(
+        #[Named('html')]
+        private readonly RenderInterface $renderer,
+        private readonly ReverseLinkerInterface $reverseLinker,
+        private readonly HtmlLinkAuditor $auditor,
+    ) {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    #[Override]
+    public function render(ResourceObject $ro)
+    {
+        $links = $this->links($ro);
+        $this->appendLinkHeader($ro, $links);
+        $ro->view = $this->renderer->render($ro);
+        $this->auditor->audit($links, $ro->view);
+
+        return $ro->view;
+    }
+
+    /** @param list<LinkHeader> $links */
+    private function appendLinkHeader(ResourceObject $ro, array $links): void
+    {
+        if ($links === []) {
+            return;
+        }
+
+        $headers = [];
+        foreach ($links as $link) {
+            $headers[] = $link->headerValue();
+        }
+
+        $header = implode(', ', $headers);
+        $current = $ro->headers[self::HEADER] ?? null;
+        if (is_string($current) && $current !== '') {
+            $ro->headers[self::HEADER] = $current . ', ' . $header;
+
+            return;
+        }
+
+        $ro->headers[self::HEADER] = $header;
+    }
+
+    /** @return list<LinkHeader> */
+    private function links(ResourceObject $ro): array
+    {
+        $method = 'on' . ucfirst($ro->uri->method);
+        if (! method_exists($ro, $method)) {
+            return [];
+        }
+
+        $body = is_array($ro->body) ? $ro->body : [];
+        $links = [];
+        foreach ((new ReflectionMethod($ro, $method))->getAnnotations() as $annotation) {
+            if (! $annotation instanceof Link) {
+                continue;
+            }
+
+            $href = uri_template($annotation->href, $body);
+            $links[] = new LinkHeader(
+                $annotation->rel,
+                $this->htmlHref($href),
+                $annotation->method,
+                $annotation->title,
+            );
+        }
+
+        return $links;
+    }
+
+    private function htmlHref(string $href): string
+    {
+        $href = ($this->reverseLinker)($href, []);
+        if (! str_starts_with($href, self::PAGE_URI_PREFIX)) {
+            return $href;
+        }
+
+        $path = substr($href, strlen(self::PAGE_URI_PREFIX));
+
+        return $path === '' ? '/' : $path;
+    }
+}

--- a/src/Http/CreateResponse.php
+++ b/src/Http/CreateResponse.php
@@ -79,8 +79,7 @@ final class CreateResponse
         $keyedHeader = [];
         array_pop($headers);
         foreach ($headers as $header) {
-            preg_match('/(.+):\s(.+)/', $header, $matched);
-            if (! array_key_exists(1, $matched) || ! array_key_exists(2, $matched)) {
+            if (preg_match('/(.+):\s(.+)/', $header, $matched) !== 1) {
                 // Skip malformed headers
                 continue;
             }

--- a/src/Http/HrefExtractor.php
+++ b/src/Http/HrefExtractor.php
@@ -142,7 +142,12 @@ final class HrefExtractor
 
     private function containsToken(string $value, string $token): bool
     {
-        $tokens = preg_split('/\s+/', trim($value));
+        $value = trim($value);
+        if ($value === '' || $token === '') {
+            return false;
+        }
+
+        $tokens = preg_split('/\s+/', $value);
         if (! is_array($tokens)) {
             return false;
         }

--- a/src/Http/HrefExtractor.php
+++ b/src/Http/HrefExtractor.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Dev\Http;
+
+use BEAR\Resource\ResourceObject;
+use stdClass;
+
+use function html_entity_decode;
+use function in_array;
+use function is_array;
+use function is_string;
+use function preg_match;
+use function preg_match_all;
+use function preg_split;
+use function strtolower;
+use function trim;
+
+use const ENT_HTML5;
+use const ENT_QUOTES;
+
+final class HrefExtractor
+{
+    public function href(string $rel, ResourceObject $ro): string|null
+    {
+        return $this->halHref($rel, $ro)
+            ?? $this->semanticHtmlHref($rel, $ro->view)
+            ?? $this->linkHeaderHref($rel, $ro->headers);
+    }
+
+    private function halHref(string $rel, ResourceObject $ro): string|null
+    {
+        $body = is_array($ro->body) ? $ro->body : [];
+        $links = $body['_links'] ?? null;
+        if ($links instanceof stdClass) {
+            $links = (array) $links;
+        }
+
+        if (! is_array($links) || ! isset($links[$rel])) {
+            return null;
+        }
+
+        $link = $links[$rel];
+        if ($link instanceof stdClass) {
+            $link = (array) $link;
+        }
+
+        if (! is_array($link)) {
+            return null;
+        }
+
+        $href = $link['href'] ?? null;
+
+        return is_string($href) ? $href : null;
+    }
+
+    private function semanticHtmlHref(string $rel, string|null $view): string|null
+    {
+        if (! is_string($view) || $view === '') {
+            return null;
+        }
+
+        if (preg_match_all('/<(?:a|area|link)\b(?P<attrs>[^>]*)>/i', $view, $matches) !== 1) {
+            return null;
+        }
+
+        foreach ($matches['attrs'] as $attrs) {
+            if (! $this->hasLinkToken($attrs, $rel)) {
+                continue;
+            }
+
+            $href = $this->attribute($attrs, 'href');
+            if ($href !== null && $href !== '') {
+                return $href;
+            }
+        }
+
+        return null;
+    }
+
+    /** @param array<string, mixed> $headers */
+    private function linkHeaderHref(string $rel, array $headers): string|null
+    {
+        $header = $this->headerValue($headers, 'Link');
+        if ($header === null) {
+            return null;
+        }
+
+        $links = preg_split('/,\s*(?=<)/', $header);
+        if (! is_array($links)) {
+            return null;
+        }
+
+        foreach ($links as $link) {
+            if (preg_match('/^\s*<([^>]*)>\s*(.*)$/', $link, $match) !== 1) {
+                continue;
+            }
+
+            $linkRel = $this->linkHeaderParam($match[2], 'rel');
+            if ($linkRel === null || ! $this->containsToken($linkRel, $rel)) {
+                continue;
+            }
+
+            return html_entity_decode($match[1], ENT_QUOTES | ENT_HTML5);
+        }
+
+        return null;
+    }
+
+    private function hasLinkToken(string $attrs, string $rel): bool
+    {
+        $relAttr = $this->attribute($attrs, 'rel');
+        if ($relAttr !== null && $this->containsToken($relAttr, $rel)) {
+            return true;
+        }
+
+        $classAttr = $this->attribute($attrs, 'class');
+
+        return $classAttr !== null && $this->containsToken($classAttr, $rel);
+    }
+
+    private function attribute(string $attrs, string $name): string|null
+    {
+        if (preg_match('/\b' . $name . '\s*=\s*(?:"([^"]*)"|\'([^\']*)\'|([^\s>]+))/i', $attrs, $match) !== 1) {
+            return null;
+        }
+
+        $value = $match[1] ?? $match[2] ?? $match[3] ?? '';
+
+        return html_entity_decode($value, ENT_QUOTES | ENT_HTML5);
+    }
+
+    private function linkHeaderParam(string $attrs, string $name): string|null
+    {
+        if (preg_match('/(?:^|;)\s*' . $name . '\s*=\s*(?:"([^"]*)"|([^;\s]+))/i', $attrs, $match) !== 1) {
+            return null;
+        }
+
+        return $match[1] ?? $match[2] ?? null;
+    }
+
+    private function containsToken(string $value, string $token): bool
+    {
+        $tokens = preg_split('/\s+/', trim($value));
+        if (! is_array($tokens)) {
+            return false;
+        }
+
+        return in_array($token, $tokens, true);
+    }
+
+    /** @param array<string, mixed> $headers */
+    private function headerValue(array $headers, string $name): string|null
+    {
+        foreach ($headers as $header => $value) {
+            if (! is_string($value)) {
+                continue;
+            }
+
+            if (strtolower($header) === strtolower($name)) {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Http/HttpResource.php
+++ b/src/Http/HttpResource.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace BEAR\Dev\Http;
 
 use BEAR\Dev\QueryMerger;
-use BEAR\Resource\Method;
 use BEAR\Resource\RequestInterface;
 use BEAR\Resource\ResourceInterface;
 use BEAR\Resource\ResourceObject;
@@ -13,8 +12,8 @@ use BEAR\Resource\Uri as ResourceUri;
 use Koriym\PhpServer\PhpServer;
 use LogicException;
 use Override;
+use stdClass;
 
-use function curl_close;
 use function curl_exec;
 use function curl_init;
 use function curl_setopt;
@@ -22,12 +21,18 @@ use function escapeshellarg;
 use function explode;
 use function file_exists;
 use function file_put_contents;
+use function html_entity_decode;
 use function http_build_query;
 use function implode;
 use function in_array;
+use function is_array;
 use function is_string;
 use function json_encode;
+use function preg_match;
+use function preg_match_all;
+use function preg_split;
 use function sprintf;
+use function strtolower;
 use function strtoupper;
 use function trim;
 
@@ -36,6 +41,8 @@ use const CURLOPT_HEADER;
 use const CURLOPT_HTTPHEADER;
 use const CURLOPT_POSTFIELDS;
 use const CURLOPT_RETURNTRANSFER;
+use const ENT_HTML5;
+use const ENT_QUOTES;
 use const FILE_APPEND;
 use const JSON_THROW_ON_ERROR;
 use const PHP_EOL;
@@ -126,11 +133,22 @@ final class HttpResource implements ResourceInterface
     #[Override]
     public function href(string $rel, array $query = [], ResourceObject|null $ro = null): ResourceObject
     {
-        throw new LogicException();
+        if (! $ro instanceof ResourceObject) {
+            throw new LogicException('ResourceObject is required to follow a link.');
+        }
+
+        $href = $this->halHref($rel, $ro)
+            ?? $this->semanticHtmlHref($rel, $ro->view)
+            ?? $this->linkHeaderHref($rel, $ro->headers);
+        if ($href === null) {
+            throw new LogicException(sprintf('Link rel `%s` is not available.', $rel));
+        }
+
+        return $this->get($href, $query);
     }
 
     /** @param array<string, mixed> $query */
-    public function newRequest(Method $method, string $uri, array $query = []): RequestInterface
+    public function newRequest(object|string $method, string $uri, array $query = []): RequestInterface
     {
         unset($method, $uri, $query);
 
@@ -223,6 +241,143 @@ final class HttpResource implements ResourceInterface
         return $this->request($url, 'get', $curlCommand);
     }
 
+    private function halHref(string $rel, ResourceObject $ro): string|null
+    {
+        $body = is_array($ro->body) ? $ro->body : [];
+        $links = $body['_links'] ?? null;
+        if ($links instanceof stdClass) {
+            $links = (array) $links;
+        }
+
+        if (! is_array($links) || ! isset($links[$rel])) {
+            return null;
+        }
+
+        $link = $links[$rel];
+        if ($link instanceof stdClass) {
+            $link = (array) $link;
+        }
+
+        if (! is_array($link)) {
+            return null;
+        }
+
+        $href = $link['href'] ?? null;
+
+        return is_string($href) ? $href : null;
+    }
+
+    private function semanticHtmlHref(string $rel, string|null $view): string|null
+    {
+        if (! is_string($view) || $view === '') {
+            return null;
+        }
+
+        if (preg_match_all('/<(?:a|area|link)\b(?P<attrs>[^>]*)>/i', $view, $matches) !== 1) {
+            return null;
+        }
+
+        foreach ($matches['attrs'] as $attrs) {
+            if (! $this->hasLinkToken($attrs, $rel)) {
+                continue;
+            }
+
+            $href = $this->attribute($attrs, 'href');
+            if ($href !== null && $href !== '') {
+                return $href;
+            }
+        }
+
+        return null;
+    }
+
+    /** @param array<string, mixed> $headers */
+    private function linkHeaderHref(string $rel, array $headers): string|null
+    {
+        $header = $this->headerValue($headers, 'Link');
+        if ($header === null) {
+            return null;
+        }
+
+        $links = preg_split('/,\s*(?=<)/', $header);
+        if (! is_array($links)) {
+            return null;
+        }
+
+        foreach ($links as $link) {
+            if (preg_match('/^\s*<([^>]*)>\s*(.*)$/', $link, $match) !== 1) {
+                continue;
+            }
+
+            $linkRel = $this->linkHeaderParam($match[2], 'rel');
+            if ($linkRel === null || ! $this->containsToken($linkRel, $rel)) {
+                continue;
+            }
+
+            return html_entity_decode($match[1], ENT_QUOTES | ENT_HTML5);
+        }
+
+        return null;
+    }
+
+    private function hasLinkToken(string $attrs, string $rel): bool
+    {
+        $relAttr = $this->attribute($attrs, 'rel');
+        if ($relAttr !== null && $this->containsToken($relAttr, $rel)) {
+            return true;
+        }
+
+        $classAttr = $this->attribute($attrs, 'class');
+
+        return $classAttr !== null && $this->containsToken($classAttr, $rel);
+    }
+
+    private function attribute(string $attrs, string $name): string|null
+    {
+        if (preg_match('/\b' . $name . '\s*=\s*(?:"([^"]*)"|\'([^\']*)\'|([^\s>]+))/i', $attrs, $match) !== 1) {
+            return null;
+        }
+
+        $value = $match[1] ?? $match[2] ?? $match[3] ?? '';
+
+        return html_entity_decode($value, ENT_QUOTES | ENT_HTML5);
+    }
+
+    private function linkHeaderParam(string $attrs, string $name): string|null
+    {
+        if (preg_match('/(?:^|;)\s*' . $name . '\s*=\s*(?:"([^"]*)"|([^;\s]+))/i', $attrs, $match) !== 1) {
+            return null;
+        }
+
+        return $match[1] ?? $match[2] ?? null;
+    }
+
+    private function containsToken(string $value, string $token): bool
+    {
+        $tokens = preg_split('/\s+/', trim($value));
+        if (! is_array($tokens)) {
+            return false;
+        }
+
+        return in_array($token, $tokens, true);
+    }
+
+    /** @param array<string, mixed> $headers */
+    private function headerValue(array $headers, string $name): string|null
+    {
+        foreach ($headers as $header => $value) {
+            if (! is_string($value)) {
+                continue;
+            }
+
+            if (strtolower($header) === strtolower($name)) {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+
     /** @param array<string, mixed> $query */
     private function unsafeRequest(string $method, string $path, array $query): ResourceObject
     {
@@ -286,7 +441,6 @@ final class HttpResource implements ResourceInterface
         }
 
         $response = curl_exec($ch);
-        curl_close($ch);
 
         if (! is_string($response)) {
             return [];

--- a/src/Http/HttpResource.php
+++ b/src/Http/HttpResource.php
@@ -12,7 +12,6 @@ use BEAR\Resource\Uri as ResourceUri;
 use Koriym\PhpServer\PhpServer;
 use LogicException;
 use Override;
-use stdClass;
 
 use function curl_exec;
 use function curl_init;
@@ -21,18 +20,12 @@ use function escapeshellarg;
 use function explode;
 use function file_exists;
 use function file_put_contents;
-use function html_entity_decode;
 use function http_build_query;
 use function implode;
 use function in_array;
-use function is_array;
 use function is_string;
 use function json_encode;
-use function preg_match;
-use function preg_match_all;
-use function preg_split;
 use function sprintf;
-use function strtolower;
 use function strtoupper;
 use function trim;
 
@@ -41,8 +34,6 @@ use const CURLOPT_HEADER;
 use const CURLOPT_HTTPHEADER;
 use const CURLOPT_POSTFIELDS;
 use const CURLOPT_RETURNTRANSFER;
-use const ENT_HTML5;
-use const ENT_QUOTES;
 use const FILE_APPEND;
 use const JSON_THROW_ON_ERROR;
 use const PHP_EOL;
@@ -54,6 +45,7 @@ final class HttpResource implements ResourceInterface
     private static PhpServer $server;
     private readonly QueryMerger $queryMerger;
     private readonly CreateResponse $createResponse;
+    private readonly HrefExtractor $hrefExtractor;
 
     public function __construct(string $host, string $index, string $logFile = 'php://stderr')
     {
@@ -64,6 +56,7 @@ final class HttpResource implements ResourceInterface
         $this->startServer($host, $index);
         $this->queryMerger = new QueryMerger();
         $this->createResponse = new CreateResponse();
+        $this->hrefExtractor = new HrefExtractor();
     }
 
     private function startServer(string $host, string $index): void
@@ -137,9 +130,7 @@ final class HttpResource implements ResourceInterface
             throw new LogicException('ResourceObject is required to follow a link.');
         }
 
-        $href = $this->halHref($rel, $ro)
-            ?? $this->semanticHtmlHref($rel, $ro->view)
-            ?? $this->linkHeaderHref($rel, $ro->headers);
+        $href = $this->hrefExtractor->href($rel, $ro);
         if ($href === null) {
             throw new LogicException(sprintf('Link rel `%s` is not available.', $rel));
         }
@@ -239,143 +230,6 @@ final class HttpResource implements ResourceInterface
         $curlCommand = sprintf('curl -s -i %s', escapeshellarg($url));
 
         return $this->request($url, 'get', $curlCommand);
-    }
-
-    private function halHref(string $rel, ResourceObject $ro): string|null
-    {
-        $body = is_array($ro->body) ? $ro->body : [];
-        $links = $body['_links'] ?? null;
-        if ($links instanceof stdClass) {
-            $links = (array) $links;
-        }
-
-        if (! is_array($links) || ! isset($links[$rel])) {
-            return null;
-        }
-
-        $link = $links[$rel];
-        if ($link instanceof stdClass) {
-            $link = (array) $link;
-        }
-
-        if (! is_array($link)) {
-            return null;
-        }
-
-        $href = $link['href'] ?? null;
-
-        return is_string($href) ? $href : null;
-    }
-
-    private function semanticHtmlHref(string $rel, string|null $view): string|null
-    {
-        if (! is_string($view) || $view === '') {
-            return null;
-        }
-
-        if (preg_match_all('/<(?:a|area|link)\b(?P<attrs>[^>]*)>/i', $view, $matches) !== 1) {
-            return null;
-        }
-
-        foreach ($matches['attrs'] as $attrs) {
-            if (! $this->hasLinkToken($attrs, $rel)) {
-                continue;
-            }
-
-            $href = $this->attribute($attrs, 'href');
-            if ($href !== null && $href !== '') {
-                return $href;
-            }
-        }
-
-        return null;
-    }
-
-    /** @param array<string, mixed> $headers */
-    private function linkHeaderHref(string $rel, array $headers): string|null
-    {
-        $header = $this->headerValue($headers, 'Link');
-        if ($header === null) {
-            return null;
-        }
-
-        $links = preg_split('/,\s*(?=<)/', $header);
-        if (! is_array($links)) {
-            return null;
-        }
-
-        foreach ($links as $link) {
-            if (preg_match('/^\s*<([^>]*)>\s*(.*)$/', $link, $match) !== 1) {
-                continue;
-            }
-
-            $linkRel = $this->linkHeaderParam($match[2], 'rel');
-            if ($linkRel === null || ! $this->containsToken($linkRel, $rel)) {
-                continue;
-            }
-
-            return html_entity_decode($match[1], ENT_QUOTES | ENT_HTML5);
-        }
-
-        return null;
-    }
-
-    private function hasLinkToken(string $attrs, string $rel): bool
-    {
-        $relAttr = $this->attribute($attrs, 'rel');
-        if ($relAttr !== null && $this->containsToken($relAttr, $rel)) {
-            return true;
-        }
-
-        $classAttr = $this->attribute($attrs, 'class');
-
-        return $classAttr !== null && $this->containsToken($classAttr, $rel);
-    }
-
-    private function attribute(string $attrs, string $name): string|null
-    {
-        if (preg_match('/\b' . $name . '\s*=\s*(?:"([^"]*)"|\'([^\']*)\'|([^\s>]+))/i', $attrs, $match) !== 1) {
-            return null;
-        }
-
-        $value = $match[1] ?? $match[2] ?? $match[3] ?? '';
-
-        return html_entity_decode($value, ENT_QUOTES | ENT_HTML5);
-    }
-
-    private function linkHeaderParam(string $attrs, string $name): string|null
-    {
-        if (preg_match('/(?:^|;)\s*' . $name . '\s*=\s*(?:"([^"]*)"|([^;\s]+))/i', $attrs, $match) !== 1) {
-            return null;
-        }
-
-        return $match[1] ?? $match[2] ?? null;
-    }
-
-    private function containsToken(string $value, string $token): bool
-    {
-        $tokens = preg_split('/\s+/', trim($value));
-        if (! is_array($tokens)) {
-            return false;
-        }
-
-        return in_array($token, $tokens, true);
-    }
-
-    /** @param array<string, mixed> $headers */
-    private function headerValue(array $headers, string $name): string|null
-    {
-        foreach ($headers as $header => $value) {
-            if (! is_string($value)) {
-                continue;
-            }
-
-            if (strtolower($header) === strtolower($name)) {
-                return $value;
-            }
-        }
-
-        return null;
     }
 
     /** @param array<string, mixed> $query */

--- a/tests/Fake/Html/LinkedResourceObject.php
+++ b/tests/Fake/Html/LinkedResourceObject.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Dev\Html;
+
+use BEAR\Resource\Annotation\Link;
+use BEAR\Resource\ResourceObject;
+
+final class LinkedResourceObject extends ResourceObject
+{
+    #[Link(rel: 'goNext', href: 'page://self/next')]
+    public function onGet(): self
+    {
+        return $this;
+    }
+}

--- a/tests/Fake/Html/RecordingHtmlLinkAuditLogger.php
+++ b/tests/Fake/Html/RecordingHtmlLinkAuditLogger.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Dev\Html;
+
+use Override;
+
+final class RecordingHtmlLinkAuditLogger implements HtmlLinkAuditLoggerInterface
+{
+    /** @var list<string> */
+    public array $warnings = [];
+
+    #[Override]
+    public function warning(LinkHeader $link, string $reason): void
+    {
+        $this->warnings[] = $link->rel . ':' . $reason;
+    }
+}

--- a/tests/Fake/Html/SemanticAnchorRenderer.php
+++ b/tests/Fake/Html/SemanticAnchorRenderer.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Dev\Html;
+
+use BEAR\Resource\RenderInterface;
+use BEAR\Resource\ResourceObject;
+use Override;
+
+final class SemanticAnchorRenderer implements RenderInterface
+{
+    #[Override]
+    public function render(ResourceObject $ro): string
+    {
+        unset($ro);
+
+        return '<a href="/next" class="goNext">Next</a>';
+    }
+}

--- a/tests/Html/ErrorLogHtmlLinkAuditLoggerTest.php
+++ b/tests/Html/ErrorLogHtmlLinkAuditLoggerTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Dev\Html;
+
+use PHPUnit\Framework\TestCase;
+
+use function assert;
+use function file_get_contents;
+use function ini_set;
+use function is_string;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
+final class ErrorLogHtmlLinkAuditLoggerTest extends TestCase
+{
+    public function testWarningSanitizesControlCharacters(): void
+    {
+        $logFile = tempnam(sys_get_temp_dir(), 'bear-dev-log');
+        assert(is_string($logFile));
+        $previousLog = ini_set('error_log', $logFile);
+
+        try {
+            (new ErrorLogHtmlLinkAuditLogger())->warning(
+                new LinkHeader("go\nNext", "/next\tpath", "po\rst"),
+                "bad\nreason",
+            );
+            $log = file_get_contents($logFile);
+            assert(is_string($log));
+
+            $this->assertStringContainsString('rel=goNext method=post href=/nextpath reason=badreason', $log);
+            $this->assertStringNotContainsString("go\nNext", $log);
+            $this->assertStringNotContainsString("bad\nreason", $log);
+        } finally {
+            ini_set('error_log', $previousLog === false ? '' : $previousLog);
+            unlink($logFile);
+        }
+    }
+}

--- a/tests/Html/ErrorLogHtmlLinkAuditLoggerTest.php
+++ b/tests/Html/ErrorLogHtmlLinkAuditLoggerTest.php
@@ -35,7 +35,9 @@ final class ErrorLogHtmlLinkAuditLoggerTest extends TestCase
             $this->assertStringNotContainsString("bad\nreason", $log);
         } finally {
             ini_set('error_log', $previousLog === false ? '' : $previousLog);
-            unlink($logFile);
+            if (is_string($logFile)) {
+                unlink($logFile);
+            }
         }
     }
 }

--- a/tests/Html/HtmlLinkAuditorTest.php
+++ b/tests/Html/HtmlLinkAuditorTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Dev\Html;
+
+use PHPUnit\Framework\TestCase;
+
+final class HtmlLinkAuditorTest extends TestCase
+{
+    private RecordingHtmlLinkAuditLogger $logger;
+    private HtmlLinkAuditor $auditor;
+
+    protected function setUp(): void
+    {
+        $this->logger = new RecordingHtmlLinkAuditLogger();
+        $this->auditor = new HtmlLinkAuditor($this->logger);
+    }
+
+    public function testMissingTarget(): void
+    {
+        $this->auditor->audit([new LinkHeader('goNext', '/next')], '<a href="/other">Other</a>');
+
+        $this->assertSame(['goNext:target-missing'], $this->logger->warnings);
+    }
+
+    public function testMissingSemanticToken(): void
+    {
+        $this->auditor->audit([new LinkHeader('goNext', '/next')], '<a href="/next">Next</a>');
+
+        $this->assertSame(['goNext:semantic-token-missing'], $this->logger->warnings);
+    }
+
+    public function testSemanticAnchor(): void
+    {
+        $this->auditor->audit([new LinkHeader('goNext', '/next')], '<a href="/next" class="goNext">Next</a>');
+
+        $this->assertSame([], $this->logger->warnings);
+    }
+
+    public function testUnsafeMethodForm(): void
+    {
+        $this->auditor->audit(
+            [new LinkHeader('doCheckout', '/checkout', 'post')],
+            '<form action="/checkout" method="post" class="doCheckout"></form>',
+        );
+
+        $this->assertSame([], $this->logger->warnings);
+    }
+
+    public function testUnsafeMethodMismatch(): void
+    {
+        $this->auditor->audit(
+            [new LinkHeader('doCheckout', '/checkout', 'post')],
+            '<a href="/checkout" class="doCheckout">Checkout</a>',
+        );
+
+        $this->assertSame(['doCheckout:method-mismatch'], $this->logger->warnings);
+    }
+}

--- a/tests/Html/HtmlLinkAuditorTest.php
+++ b/tests/Html/HtmlLinkAuditorTest.php
@@ -38,6 +38,13 @@ final class HtmlLinkAuditorTest extends TestCase
         $this->assertSame([], $this->logger->warnings);
     }
 
+    public function testEmptyTokenDoesNotMatchEmptyRelOrClass(): void
+    {
+        $affordance = new HtmlAffordance('/next', 'get');
+
+        $this->assertFalse($affordance->hasToken(''));
+    }
+
     public function testUnsafeMethodForm(): void
     {
         $this->auditor->audit(

--- a/tests/Html/LinkHeaderRendererTest.php
+++ b/tests/Html/LinkHeaderRendererTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Dev\Html;
+
+use BEAR\Resource\NullReverseLinker;
+use BEAR\Resource\RenderInterface;
+use BEAR\Resource\ReverseLinkerInterface;
+use BEAR\Resource\Uri;
+use Override;
+use PHPUnit\Framework\TestCase;
+use Ray\Di\AbstractModule;
+use Ray\Di\Injector;
+
+final class LinkHeaderRendererTest extends TestCase
+{
+    public function testRenderAddsLinkHeaderAndAuditsRenderedHtml(): void
+    {
+        $logger = new RecordingHtmlLinkAuditLogger();
+        $renderer = new LinkHeaderRenderer(
+            new SemanticAnchorRenderer(),
+            new NullReverseLinker(),
+            new HtmlLinkAuditor($logger),
+        );
+        $ro = new LinkedResourceObject();
+        $ro->uri = new Uri('page://self/current');
+        $ro->uri->method = 'get';
+        $ro->body = [];
+
+        $view = $renderer->render($ro);
+
+        $this->assertSame('<a href="/next" class="goNext">Next</a>', $view);
+        $this->assertSame('</next>; rel="goNext"; method="get"', $ro->headers['Link']);
+        $this->assertSame([], $logger->warnings);
+    }
+
+    public function testModuleRenamesPreviousRenderer(): void
+    {
+        $injector = new Injector(new LinkHeaderModule(new class extends AbstractModule {
+            #[Override]
+            protected function configure(): void
+            {
+                $this->bind(RenderInterface::class)->to(SemanticAnchorRenderer::class);
+                $this->bind(ReverseLinkerInterface::class)->to(NullReverseLinker::class);
+                $this->bind(HtmlLinkAuditLoggerInterface::class)->toInstance(new RecordingHtmlLinkAuditLogger());
+            }
+        }));
+        $renderer = $injector->getInstance(RenderInterface::class);
+
+        $this->assertInstanceOf(LinkHeaderRenderer::class, $renderer);
+    }
+}

--- a/tests/Http/HttpResourceTest.php
+++ b/tests/Http/HttpResourceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BEAR\Dev\Http;
 
+use BEAR\Resource\NullResourceObject;
 use PHPUnit\Framework\TestCase;
 
 use function assert;
@@ -56,6 +57,52 @@ class HttpResourceTest extends TestCase
         $ro = $this->resource->delete('/');
         $this->assertSame(200, $ro->code);
         $this->assertStringContainsString('"method": "onDelete"', $ro->view);
+    }
+
+    public function testHrefFollowsHalLinkFirst(): void
+    {
+        $ro = new NullResourceObject();
+        $ro->body = [
+            '_links' => [
+                'goHome' => ['href' => '/'],
+            ],
+        ];
+        $ro->view = '<a href="/other" class="goHome">Other</a>';
+        $ro->headers = ['Link' => '</header>; rel="goHome"'];
+
+        $next = $this->resource->href('goHome', [], $ro);
+
+        $this->assertSame(200, $next->code);
+        $this->assertStringContainsString('"method": "onGet"', $next->view);
+        $this->assertSame('http://127.0.0.1:8080/', (string) $next->uri);
+    }
+
+    public function testHrefFollowsSemanticHtmlLinkBeforeHeader(): void
+    {
+        $ro = new NullResourceObject();
+        $ro->body = [];
+        $ro->view = '<a href="/" class="goHome">Home</a>';
+        $ro->headers = ['Link' => '</header>; rel="goHome"'];
+
+        $next = $this->resource->href('goHome', [], $ro);
+
+        $this->assertSame(200, $next->code);
+        $this->assertStringContainsString('"method": "onGet"', $next->view);
+        $this->assertSame('http://127.0.0.1:8080/', (string) $next->uri);
+    }
+
+    public function testHrefFallsBackToLinkHeader(): void
+    {
+        $ro = new NullResourceObject();
+        $ro->body = [];
+        $ro->view = '<a href="/other">Other</a>';
+        $ro->headers = ['Link' => '</>; rel="goHome"'];
+
+        $next = $this->resource->href('goHome', [], $ro);
+
+        $this->assertSame(200, $next->code);
+        $this->assertStringContainsString('"method": "onGet"', $next->view);
+        $this->assertSame('http://127.0.0.1:8080/', (string) $next->uri);
     }
 
     public function testStdErrLog(): void


### PR DESCRIPTION
## Summary
- Add BEAR\Dev\Html\LinkHeaderModule and LinkHeaderRenderer.
- Expose #[Link] contracts as HTTP Link headers for HTML rendering.
- Add HTML link audit logging for missing target, missing semantic token, method mismatch, and sanitized warning output.
- Teach BEAR\Dev\Http\HttpResource::href() to follow HAL, semantic HTML links, then Link headers via extracted href discovery.

## Validation
- composer test
- composer cs
- PHP_INI_SCAN_DIR=/private/tmp/bear-devtools-php-ini composer sa
- composer phpmd
