### PR TITLE
Move PHPUnit to DevTools dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
         "bear/app-meta": "^1.8",
         "bear/resource": "^1.31",
         "koriym/php-server": "^1.0",
-        "phpunit/phpunit": "^9.6",
         "ray/aop": "^2.14",
         "ray/di": "^2.14"
     },
@@ -22,6 +21,7 @@
         "bamarni/composer-bin-plugin": "^1.4",
         "bear/package": "^1.10",
         "madapaja/twig-module": "^2.5",
+        "phpunit/phpunit": "^9.6 || ^10.0",
         "ray/aura-sql-module": "^1.10",
         "xhprof/xhprof": "^2.3"
     },


### PR DESCRIPTION
## Summary
- Move `phpunit/phpunit` from runtime `require` to `require-dev`.
- Allow PHPUnit 10 for DevTools development installs while keeping PHPUnit 9 support.

## Why
`bear/devtools` is used as a runtime dependency by applications that want the HTML `Link` header renderer during development workflows. Keeping PHPUnit in runtime `require` forces downstream applications to resolve PHPUnit 9, which conflicts with applications using PHPUnit 10.

## Checks
- `composer validate --strict`
- `vendor/bin/phpunit tests/Html`
- `vendor/bin/phpcs --standard=./phpcs.xml src tests`
- `php -d memory_limit=512M vendor/bin/phpstan analyse -c phpstan.neon`
- `vendor/bin/psalm --show-info=true`